### PR TITLE
Use `$0` for `record.again`

### DIFF
--- a/record-gif.sh
+++ b/record-gif.sh
@@ -69,7 +69,7 @@ create_replay() {
   local duration=$2
   local save_as=$3
 
-  echo "record-gif.sh $duration $save_as ${seletected_area}" > $HOME/.record.again
+  echo "$0 $duration $save_as ${seletected_area}" > $HOME/.record.again
   chmod u+x $HOME/.record.again
 }
 run() {

--- a/record-gif.sh
+++ b/record-gif.sh
@@ -67,9 +67,10 @@ remove_existing() {
 create_replay() {
   local seletected_area="$1"
   local duration=$2
-  local save_as=$3
+  local save_as="$3"
+  local executable="$0"
 
-  echo "$0 $duration $save_as ${seletected_area}" > $HOME/.record.again
+  echo "$executable $duration $save_as ${seletected_area}" > $HOME/.record.again
   chmod u+x $HOME/.record.again
 }
 run() {


### PR DESCRIPTION
This way, it works even when the script is e.g. symlinked to a `record-gif` (no `.sh`) or used via `./record-gif.sh` without being in `$PATH`.